### PR TITLE
fix: Add 'events' block to nginx.conf

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -1,3 +1,5 @@
+events{}
+
 http {
     include /etc/nginx/mime.types;
 


### PR DESCRIPTION
This change adds the 'events' block at the top of the nginx.conf file. It is required by the Nginx configuration syntax to ensure proper functioning.