### PR TITLE
fix: Update Dockerfile to correct asset directories

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
 FROM nginx:alpine3.18
 
 COPY ./nginx.conf /etc/nginx/nginx.conf
-COPY ./css /usr/share/nginx/html
-COPY ./font /usr/share/nginx/html
-COPY ./img /usr/share/nginx/html
+COPY ./css /usr/share/nginx/html/css
+COPY ./font /usr/share/nginx/html/font
+COPY ./img /usr/share/nginx/html/img
 COPY ./index.html /usr/share/nginx/html
 
 EXPOSE 80


### PR DESCRIPTION
This change ensures CSS, font, and image assets are copied to the correct subdirectories within /usr/share/nginx/html. This organization improves file structure and aligns with expected paths used in nginx configuration.